### PR TITLE
Fix TypeScript argument error

### DIFF
--- a/src/components/EyeTrackingHeatmap.tsx
+++ b/src/components/EyeTrackingHeatmap.tsx
@@ -30,7 +30,7 @@ const EyeTrackingHeatmap: React.FC = () => {
         if (!videoRef.current || !canvasRef.current || !heatmapCanvasRef.current) return
 
         // Initialize eye tracker
-        const eyeTracker = new EyeTracker(videoRef.current, canvasRef.current)
+        const eyeTracker = new EyeTracker(videoRef.current)
         await eyeTracker.initialize()
         eyeTrackerRef.current = eyeTracker
 


### PR DESCRIPTION
Remove unnecessary second argument from `EyeTracker` constructor call to fix TypeScript error.